### PR TITLE
Update Dockerfile for file permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git
 .env
 dist/*
 node_modules/*
+bundle/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM registry.access.redhat.com/ubi8/nodejs-16
 
 RUN npm install -g yarn
 
-ADD . ${APP_ROOT}
 WORKDIR ${APP_ROOT}
 
-RUN yarn install && yarn build
+COPY --chown=default:root package.json yarn.lock ./
+RUN yarn install
+COPY --chown=default:root . ./
+RUN yarn build
 
 EXPOSE 4000
 CMD ["yarn", "run", "server"]


### PR DESCRIPTION
Use `COPY --chown=default:root` to avoid file permission issues like 
```
error An unexpected error occurred: "EACCES: permission denied, mkdir '/opt/app-root/node_modules/accepts'".
```
when running `make build`.

Also sync `.gitignore` to `.dockerignore` to reduce file size in local development mode.

Signed-off-by: Di Wang <dwan@redhat.com>